### PR TITLE
i18n: don't rely on platform charset when generating messages.js

### DIFF
--- a/axelor-web/src/main/java/com/axelor/web/servlet/I18nServlet.java
+++ b/axelor-web/src/main/java/com/axelor/web/servlet/I18nServlet.java
@@ -36,6 +36,7 @@ import com.axelor.app.internal.AppFilter;
 import com.axelor.i18n.I18n;
 import com.axelor.inject.Beans;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.base.Charsets;
 
 @Singleton
 public class I18nServlet extends HttpServlet {
@@ -91,7 +92,7 @@ public class I18nServlet extends HttpServlet {
 			return;
 		}
 
-		out.write(builder.toString().getBytes());
+		out.write(builder.toString().getBytes(Charsets.UTF_8));
 		out.close();
 	}
 }


### PR DESCRIPTION
Fixes wrong encoding in js/messages.js when running tomcat on windows.