### PR TITLE
ui: allow to close tab through middle click

### DIFF
--- a/axelor-web/src/main/webapp/js/form/form.input.static.js
+++ b/axelor-web/src/main/webapp/js/form/form.input.static.js
@@ -162,6 +162,13 @@ function makePopover(scope, element, callback, placement) {
 			table.remove();
 			table = null;
 		}
+		// Handle tab case with middle click closing
+		// where we haven't received the 'leave' event
+		// when destroying
+		if (popoverTimer) {
+			clearTimeout(popoverTimer);
+			popoverTimer = null;
+		}
 		doc.off('mousemove.popover');
 	}
 	

--- a/axelor-web/src/main/webapp/partials/nav-tabs.html
+++ b/axelor-web/src/main/webapp/partials/nav-tabs.html
@@ -5,7 +5,7 @@
 	<div class="nav-tabs-strip">
 	<ul class="nav nav-tabs nav-tabs-main nav-tabs-scrollable nav-tabs-closable">
 	 <li ng-repeat="tab in navTabs" ng-class="{ active: tab.selected, notclosable: !canCloseTab(tab), dirty: tabDirty(tab) }">
-	   <a href="" ng-click="navClick(tab)">
+	   <a href="" ng-click="navClick(tab)" ng-mousedown="$event.which == 2 && closeTab(tab)">
 	     <img class="prefix-icon" ng-show="tab.icon" ng-src="{{tab.icon}}"><span ui-tab-popover>{{tabTitle(tab)}}</span>
 	   </a>
 	   <i ng-show="canCloseTab(tab)" class="fa fa-times" ng-click="closeTab(tab)"></i>


### PR DESCRIPTION
Adopt standard behavior for tabs where middle click close them instead of
opening one blank tab.