### PR TITLE
#14: fix issue when IN has empty parameter

### DIFF
--- a/axelor-core/src/main/java/com/axelor/rpc/filter/RangeFilter.java
+++ b/axelor-core/src/main/java/com/axelor/rpc/filter/RangeFilter.java
@@ -46,6 +46,13 @@ class RangeFilter extends SimpleFilter {
 					getOperator());
 		}
 
+		if (values.isEmpty()) {
+			if (getOperator() == Operator.IN)
+				return "false";
+			else if (getOperator() == Operator.NOT_IN)
+				return "true";
+		}
+
 		StringBuilder sb = new StringBuilder("self.").append(getFieldName());
 		sb.append(" ").append(getOperator()).append(" (");
 


### PR DESCRIPTION
It seems logical that "IN ()" is always false and "NOT IN ()" is always true. Except maybe for null if you want to follow the SQL logic.
If you don't want to implement this logic, then you should raise an exception instead of silently trapping it.