### PR TITLE
entity: add new entity-listener tag

### DIFF
--- a/axelor-core/src/main/resources/domain-models.xsd
+++ b/axelor-core/src/main/resources/domain-models.xsd
@@ -949,6 +949,14 @@
           </xsd:documentation>
         </xsd:annotation>
       </xsd:element>
+      <xsd:element name="entity-listener" type="dm:EntityListener" minOccurs="0" maxOccurs="unbounded">
+        <xsd:annotation>
+          <xsd:documentation>
+            Define class containing annotated methods (@PrePersist, etc.) that will be called
+            during entity lifecycle.
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
     </xsd:sequence>
 
     <xsd:attribute use="required" name="name">
@@ -1155,6 +1163,22 @@
           Specify whether to use numeric values, all enum items must provide a numeric value.
         </xsd:documentation>
       </xsd:annotation>
+    </xsd:attribute>
+  </xsd:complexType>
+
+  <xsd:complexType name="EntityListener">
+    <xsd:attribute name="class" use="required">
+      <xsd:simpleType>
+        <xsd:annotation>
+          <xsd:documentation>
+            FQDN of the listener class
+          </xsd:documentation>
+        </xsd:annotation>
+        <xsd:restriction base="xsd:string">
+          <xsd:pattern
+            value="(([a-z][a-zA-Z0-9_]+)(\.[a-z][a-zA-Z0-9_]+)*\.)?([A-Z][a-zA-Z0-9_]+)" />
+        </xsd:restriction>
+      </xsd:simpleType>
     </xsd:attribute>
   </xsd:complexType>
 </xsd:schema>


### PR DESCRIPTION
Allow entities to declare listeners that'll be invoked during lifecycle.
This allows to perform consistency checks in a more reliable way than
overriding repository save() method as listeners are called even in case
of cascading persist.
Annotation has been modified to allow avoiding imports since for
@EntityListeners we need to pass .class which doesn't play well with
autoimport. Alternative would have been to import and append '.class' to
annotation param by the mean of another boolean parameter.