### PR TITLE
tabs: properly clear popover timeout

### DIFF
--- a/axelor-web/src/main/webapp/js/form/form.input.static.js
+++ b/axelor-web/src/main/webapp/js/form/form.input.static.js
@@ -186,7 +186,7 @@ function setupPopover(scope, element, getHelp, placement) {
 			element.trigger('mouseenter.popover', true);
 		}, e.ctrlKey ? 0 : 1000);
 	});
-	element.on('mouseleave.help.setup', function () {
+	element.on('mouseleave.help.setup $destroy', function () {
 		if (timer) {
 			clearTimeout(timer);
 			timer = null;


### PR DESCRIPTION
One of the tab's popover timeout wasn't correctly clear on destroy
causing dangling popover in the upper left corner when most-left tab was
closed through middle click.