### PR TITLE
modules: fix uninstall

### DIFF
--- a/axelor-core/src/main/java/com/axelor/meta/web/ModuleController.java
+++ b/axelor-core/src/main/java/com/axelor/meta/web/ModuleController.java
@@ -99,7 +99,7 @@ public class ModuleController {
 		final Set<String> all = new HashSet<>();
 		all.add(module.getName());
 		for (MetaModule metaModule : modules.all()
-				.filter("self.depends LIKE ?1", "%" + module.getName() + "%").fetch()) {
+				.filter("?1 MEMBER OF self.depends", module.getId()).fetch()) {
 			if (metaModule.getApplication() == Boolean.TRUE ||
 				metaModule.getInstalled() != Boolean.TRUE ||
 				mainModule.equals(metaModule.getName())) {


### PR DESCRIPTION
Commit b5968d4 forgot to adjust ModuleManager::resolveLink which was
still performing a LIKE against a collection causing an invalid
parameter error when attempting to uninstall any module from
Administration section.