### PR TITLE
form: check for parent to determine if an element is hidden

### DIFF
--- a/axelor-web/src/main/webapp/js/form/form.base.js
+++ b/axelor-web/src/main/webapp/js/form/form.base.js
@@ -180,7 +180,7 @@ ui.formCompile = function(element, attrs, linkerFn) {
     };
 
     scope.isHidden = function() {
-      return this.attr("hidden") || false;
+      return this.attr("hidden") || (this.$parent && this.$parent.isHidden && this.$parent.isHidden()) || false;
     };
 
     scope.fireAction = function(name, success, error) {


### PR DESCRIPTION
isHidden only checks for current element being hidden, this leads to
false negative when eg. element is in an hidden panel (for exemple
productName in SaleOrderLine.xml which is present twice, only one of the
two being displayed).

This fixes a double error message in SaleOrderLine popup when product label is empty