### PR TITLE
Fix performance issues during grid inline editing

### DIFF
--- a/axelor-web/src/main/webapp/js/widget/widget.slickgrid.js
+++ b/axelor-web/src/main/webapp/js/widget/widget.slickgrid.js
@@ -2323,9 +2323,11 @@ function commitEdit(noWait) {
 
     // Force fetch if pop-up form view is opened.
     // This is needed if form view has fields no present in grid view.
+    data.beginUpdate();
     _.forEach(data.getItems(), function(item) {
       data.updateItem(item.id, _.extend(item || {}, { $fetched: false }));
     });
+    data.endUpdate();
   }
 
   this._commitPromise = promise;

--- a/changelogs/unreleased/fix_grid_inline_edit_freeze.yml
+++ b/changelogs/unreleased/fix_grid_inline_edit_freeze.yml
@@ -1,0 +1,3 @@
+---
+title: Fix performance issues during grid inline editing
+type: fix


### PR DESCRIPTION
Fixes #102  : performance issue with grid inline editing

Use transactions to improve updateItem speed for multiple items changes 