### PR TITLE
fix: expected output changelog order

### DIFF
--- a/axelor-tools/src/test/resources/changelogs/EXPECTED_CHANGELOG.md
+++ b/axelor-tools/src/test/resources/changelogs/EXPECTED_CHANGELOG.md
@@ -26,6 +26,7 @@
 
 #### Fixed
 
+* Fix going into edit mode in editable grid with large horizontal scrolling
 * Fix m2m field update issue
 
   <details>
@@ -37,8 +38,6 @@
   with all necessary fields by itself.
   
   </details>
-
-* Fix going into edit mode in editable grid with large horizontal scrolling
 
 #### Security
 


### PR DESCRIPTION
When running `./gradlew test`, ChangelogTest fails because the `simple.yml` file is read before `withDescription.yml`, so the `simple.yml` title will be print before `withDescription.yml`title. In `EXPECTED_CHANGELOG.md`, the order is different.