### PR TITLE
[Doc] Fix missing quote in tutorial/step4

### DIFF
--- a/documentation/modules/tutorial/pages/step4.adoc
+++ b/documentation/modules/tutorial/pages/step4.adoc
@@ -53,7 +53,7 @@ we'll see how to create `grid` and `form` views for the `Contact` model:
     <panel name="aboutMePanel" title="About me">
         <field name="notes" showTitle="false" colSpan="12"/>
     </panel>
-    <panel-related name="addressesPanel
+    <panel-related name="addressesPanel"
                    field="addresses" <6>
                    form-view="address-form-popup"> <7>
         <field name="street"/>


### PR DESCRIPTION
There is an error in the code of the example file `axelor-contact/src/main/resources/views/Contact.xml` in step 4 of the [Quick Tutorial](https://docs.axelor.com/adk/5.4/tutorial/index.html).

The error, which is a missing quote, causes the XML to be invalid.
![image](https://user-images.githubusercontent.com/46165291/210512316-ec46217c-1f28-4659-ae46-feb4486a1cd2.png)

This error can be found in the following versions of the tutorial:

- [5.4](https://docs.axelor.com/adk/5.4/tutorial/step4.html)
- [6.0](https://docs.axelor.com/adk/6.0/tutorial/step4.html)
- [6.1](https://docs.axelor.com/adk/6.1/tutorial/step4.html)

